### PR TITLE
Add 'Home Assignment' Custom Module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "composer/installers": "^1.2",
         "drupal/core-composer-scaffold": "^8.8",
         "drupal/core-recommended": "^8.8",
+        "drupal/og": "^1.0@alpha",
         "drush/drush": "^10.2"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8a41fb997a61f05dbc4d5bf7683ad348",
+    "content-hash": "7d734960a09b1469c01694b86f7b98dc",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1906,6 +1906,101 @@
             ],
             "description": "Locked core dependencies; require this project INSTEAD OF drupal/core.",
             "time": "2020-04-02T19:01:19+00:00"
+        },
+        {
+            "name": "drupal/og",
+            "version": "1.0.0-alpha5",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/og.git",
+                "reference": "8.x-1.0-alpha5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/og-8.x-1.0-alpha5.zip",
+                "reference": "8.x-1.0-alpha5",
+                "shasum": "f4a446191885c076ee97a913b09d19c3960976af"
+            },
+            "require": {
+                "drupal/core": "~8.7",
+                "php": ">=7.1.0"
+            },
+            "require-dev": {
+                "drupal/coder": "~8.2"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.0-alpha5",
+                    "datestamp": "1585733421",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Alpha releases are not covered by Drupal security advisories."
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Dries",
+                    "homepage": "https://www.drupal.org/user/1"
+                },
+                {
+                    "name": "Grayside",
+                    "homepage": "https://www.drupal.org/user/346868"
+                },
+                {
+                    "name": "RoySegall",
+                    "homepage": "https://www.drupal.org/user/1812910"
+                },
+                {
+                    "name": "Zen",
+                    "homepage": "https://www.drupal.org/user/21209"
+                },
+                {
+                    "name": "alesr",
+                    "homepage": "https://www.drupal.org/user/150704"
+                },
+                {
+                    "name": "amitaibu",
+                    "homepage": "https://www.drupal.org/user/57511"
+                },
+                {
+                    "name": "dww",
+                    "homepage": "https://www.drupal.org/user/46549"
+                },
+                {
+                    "name": "merlinofchaos",
+                    "homepage": "https://www.drupal.org/user/26979"
+                },
+                {
+                    "name": "moshe weitzman",
+                    "homepage": "https://www.drupal.org/user/23"
+                },
+                {
+                    "name": "mpp",
+                    "homepage": "https://www.drupal.org/user/359881"
+                },
+                {
+                    "name": "pfrenssen",
+                    "homepage": "https://www.drupal.org/user/382067"
+                },
+                {
+                    "name": "sethcohn",
+                    "homepage": "https://www.drupal.org/user/14944"
+                }
+            ],
+            "description": "API to allow associating content with groups.",
+            "homepage": "https://drupal.org/project/og",
+            "support": {
+                "source": "https://git.drupalcode.org/project/og",
+                "issues": "https://drupal.org/project/issues/og",
+                "irc": "irc://irc.freenode.org/drupal-og",
+                "slack": "https://drupal.slack.com/messages/CELR48EA0"
+            }
         },
         {
             "name": "drush/drush",
@@ -7551,7 +7646,9 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {
+        "drupal/og": 15
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": [],

--- a/web/modules/custom/home_assignment/README
+++ b/web/modules/custom/home_assignment/README
@@ -1,0 +1,26 @@
+Home Assignment
+===============
+
+Installation
+------------
+- Install the module as any other module] from "admin/modules". This depends on Organic Groups (og) module.
+
+Configuration
+-------------
+- Once installed, a new content type called "Group" (machine_name: ha_group) will be created.
+- A new field formatter plugin for "og_group" is present within this module and this field formatter will be set once
+this module is installed. This can be configured in "admin/structure/types/manage/ha_group/display".
+- The "Home Assignment Group Subscribe" field formatter has 2 settings fields for OG subscription message (one with
+approval and one without). These messages can contain 2 tokens "%user" and "%group" which will be replaced by the
+current user name and the group name respectively.
+
+Default Behaviour
+-----------------
+When this module is just installed and a node of type "Group" (ha_group) is created and if an authenticated user visits
+the group, they will see the default message, "Hi %user, click here if you would like to subscribe to this group called
+%group" where %user will be the current user's name and %group will be the group name.
+
+Uninstall
+---------
+On uninstall the new content type "Group" (ha_group) will not be deleted. The field formatter will not be available and
+will be switched to the default "OG Group subscribe" formatter.

--- a/web/modules/custom/home_assignment/config/install/core.entity_form_display.node.ha_group.default.yml
+++ b/web/modules/custom/home_assignment/config/install/core.entity_form_display.node.ha_group.default.yml
@@ -1,0 +1,76 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.ha_group.body
+    - node.type.ha_group
+  module:
+    - path
+    - text
+id: node.ha_group.default
+targetEntityType: node
+bundle: ha_group
+mode: default
+content:
+  body:
+    type: text_textarea_with_summary
+    weight: 121
+    settings:
+      rows: 9
+      summary_rows: 3
+      placeholder: ''
+      show_summary: false
+    third_party_settings: {  }
+    region: content
+  created:
+    type: datetime_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 15
+    region: content
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 120
+    region: content
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 16
+    region: content
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+      match_limit: 10
+    region: content
+    third_party_settings: {  }
+hidden: {  }

--- a/web/modules/custom/home_assignment/config/install/core.entity_view_display.node.ha_group.default.yml
+++ b/web/modules/custom/home_assignment/config/install/core.entity_view_display.node.ha_group.default.yml
@@ -1,0 +1,37 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.ha_group.body
+    - node.type.ha_group
+  module:
+    - home_assignment
+    - text
+    - user
+id: node.ha_group.default
+targetEntityType: node
+bundle: ha_group
+mode: default
+content:
+  body:
+    label: hidden
+    type: text_default
+    weight: 101
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+  links:
+    weight: 100
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  og_group:
+    weight: 0
+    type: home_assignment_group_subscribe
+    region: content
+    label: above
+    settings:
+      sub_message: 'Hi %user, click here if you would like to subscribe to this group called %group'
+      sub_message_approval: 'Hi %user, click here if you would like to subscribe to this group called %group'
+    third_party_settings: {  }
+hidden: {  }

--- a/web/modules/custom/home_assignment/config/install/field.field.node.ha_group.body.yml
+++ b/web/modules/custom/home_assignment/config/install/field.field.node.ha_group.body.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.body
+    - node.type.ha_group
+  module:
+    - text
+id: node.ha_group.body
+field_name: body
+entity_type: node
+bundle: ha_group
+label: Body
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: true
+  required_summary: false
+field_type: text_with_summary

--- a/web/modules/custom/home_assignment/config/install/node.type.ha_group.yml
+++ b/web/modules/custom/home_assignment/config/install/node.type.ha_group.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_ui
+third_party_settings:
+  menu_ui:
+    available_menus:
+      - main
+    parent: 'main:'
+name: Group
+type: ha_group
+description: 'A test content type for Home Assignment.'
+help: ''
+new_revision: true
+preview_mode: 1
+display_submitted: true

--- a/web/modules/custom/home_assignment/config/schema/home_assignment.schema.yml
+++ b/web/modules/custom/home_assignment/config/schema/home_assignment.schema.yml
@@ -1,0 +1,10 @@
+field.formatter.settings.home_assignment_group_subscribe:
+  type: mapping
+  label: 'Home assignment group subscription'
+  mapping:
+    sub_message:
+      type: string
+      label: 'OG Subscribe Message'
+    sub_message_approval:
+      type: string
+      label: 'OG Subscribe Message (approval required)'

--- a/web/modules/custom/home_assignment/home_assignment.info.yml
+++ b/web/modules/custom/home_assignment/home_assignment.info.yml
@@ -1,0 +1,11 @@
+name: Home Assignment
+description: Sample task using OG.
+package: Custom
+
+core: 8.x
+type: module
+
+dependencies:
+  - drupal:og_ui
+
+version: '8.x-1.0'

--- a/web/modules/custom/home_assignment/home_assignment.install
+++ b/web/modules/custom/home_assignment/home_assignment.install
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @file
+ * Install file for home_assignment module.
+ */
+
+use Drupal\Core\Config\FileStorage;
+use Drupal\og\Og;
+
+/**
+ * Implements hook_install().
+ */
+function home_assignment_install() {
+  // Import custom content type.
+  $config_path = drupal_get_path('module', 'home_assignment') . '/config/install';
+  $source = new FileStorage($config_path);
+  $config_storage = \Drupal::service('config.storage');
+  $config_files = \Drupal::service('file_system')->scanDirectory($config_path, '/.*\.yml$/');
+  foreach ($config_files as $config_file) {
+    $config_storage->write($config_file->name, $source->read($config_file->name));
+  }
+
+  // Add content type as a group.
+  Og::addGroup('node', 'ha_group');
+  drupal_flush_all_caches();
+}

--- a/web/modules/custom/home_assignment/src/Plugin/Field/FieldFormatter/HAGroupSubscribeFormatter.php
+++ b/web/modules/custom/home_assignment/src/Plugin/Field/FieldFormatter/HAGroupSubscribeFormatter.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Drupal\home_assignment\Plugin\Field\FieldFormatter;
+
+use Drupal\og\Plugin\Field\FieldFormatter\GroupSubscribeFormatter;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\user\Entity\User;
+
+/**
+ * Plugin implementation for the OG subscribe formatter.
+ *
+ * @FieldFormatter(
+ *   id = "home_assignment_group_subscribe",
+ *   label = @Translation("Home Assignment Group subscribe"),
+ *   description = @Translation("Display OG Group subscribe and un-subscribe links."),
+ *   field_types = {
+ *     "og_group"
+ *   }
+ * )
+ */
+class HAGroupSubscribeFormatter extends GroupSubscribeFormatter {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {
+    $elements = parent::viewElements($items, $langcode);
+
+    // Do not continue if element is not a subscription link.
+    if ($elements[0]['#type'] != 'link') {
+      return $elements;
+    }
+
+    // We want to update link only for 'authenticated' users.
+    $user = $this->entityTypeManager->load(($this->currentUser->id()));
+    if ($user instanceof User && !$user->hasRole('authenticated')) {
+      return $elements;
+    }
+
+    $group = $items->getEntity();
+    $settings = $this->getSettings();
+    $tokens = [
+      '%user' => $user->getDisplayName(),
+      '%group' => $group->label(),
+    ];
+
+    // Update subscription links as configured in field formatter settings.
+    if (($access = $this->ogAccess->userAccess($group, 'subscribe without approval', $user))
+      && $access->isAllowed()) {
+      $elements[0]['#title'] = self::replaceTokens($settings['sub_message'], $tokens);
+    }
+    elseif (($access = $this->ogAccess->userAccess($group, 'subscribe', $user))
+      && $access->isAllowed()) {
+      $elements[0]['#title'] = self::replaceTokens($settings['sub_message_approval'], $tokens);
+    }
+
+    return $elements;
+  }
+
+  /**
+   * A simple token replacement.
+   *
+   * @param string $str
+   *   The subject string.
+   * @param array $tokens
+   *   An array of tokens and their values.
+   *
+   * @return string|string[]
+   *   The subject string with tokens replaced (if applicable).
+   */
+  public static function replaceTokens($str, array $tokens) {
+    foreach ($tokens as $token => $value) {
+      if (strpos($str, $token) === FALSE) {
+        continue;
+      }
+      $str = str_replace($token, $value, $str);
+    }
+
+    return $str;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultSettings() {
+    return [
+      'sub_message' => t('Hi %user, click here if you would like to subscribe to this group called %group'),
+      'sub_message_approval' => t('Hi %user, click here if you would like to subscribe to this group called %group'),
+    ] + parent::defaultSettings();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsForm(array $form, FormStateInterface $form_state) {
+    $defaults = self::defaultSettings();
+    $default_value = $defaults['sub_message'];
+    if (isset($this->settings['sub_message'])) {
+      $default_value = $this->settings['sub_message'];
+    }
+    $form['sub_message'] = [
+      '#title' => $this->t('OG Subscribe Message'),
+      '#type' => 'textfield',
+      '#description' => $this->t('Use %user token for user name and %group for group name'),
+      '#default_value' => $default_value,
+    ];
+
+    $default_value = $defaults['sub_message_approval'];
+    if (isset($this->settings['sub_message_approval'])) {
+      $default_value = $this->settings['sub_message_approval'];
+    }
+    $form['sub_message_approval'] = [
+      '#title' => $this->t('OG Subscribe Message (approval required)'),
+      '#type' => 'textfield',
+      '#description' => $this->t('Use %user token for user name and %group for group name'),
+      '#default_value' => $default_value,
+    ];
+
+    return $form;
+  }
+
+}

--- a/web/modules/custom/home_assignment/tests/src/ExistingSite/HomeAssignmentTest.php
+++ b/web/modules/custom/home_assignment/tests/src/ExistingSite/HomeAssignmentTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Drupal\Tests\home_assignment\ExistingSite;
+
+use weitzman\DrupalTestTraits\ExistingSiteBase;
+use Behat\Mink\Exception\ExpectationException;
+use Drupal\home_assignment\Plugin\Field\FieldFormatter\HAGroupSubscribeFormatter;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+
+/**
+ * A model test case using traits from Drupal Test Traits.
+ */
+class HomeAssignmentTest extends ExistingSiteBase {
+  use StringTranslationTrait;
+
+  /**
+   * An example test method; note that Drupal API's and Mink are available.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   * @throws \Drupal\Core\Entity\EntityMalformedException
+   * @throws \Behat\Mink\Exception\ExpectationException
+   */
+  public function testGroupSubscriptionMessage() {
+    // Get view modes for bundle.
+    $view_modes = \Drupal::service('entity_display.repository')
+      ->getViewModeOptionsByBundle(
+        'node', 'ha_group'
+      );
+    $view_mode = 'default';
+    if (in_array('full', $view_modes)) {
+      $view_mode = 'full';
+    }
+
+    // Check if the view mode is using 'home_assignment_group_subscribe' plugin.
+    $config = \Drupal::service('entity_type.manager')
+      ->getStorage('entity_view_display')
+      ->load('node.ha_group.' . $view_mode)
+      ->getRenderer('og_group');
+    $plugin_id = $config->getPluginId();
+    if ($plugin_id != 'home_assignment_group_subscribe') {
+      $this->assertEqual(
+        TRUE,
+        TRUE,
+        $this->t('Home Assignment custom field formatter not in use for full/default view mode.')
+      );
+      return;
+    }
+
+    // Create test user.
+    $user = $this->createUser([], 'tester', TRUE);
+
+    // Create test group.
+    $node = $this->createNode([
+      'title' => 'Test Group',
+      'type' => 'ha_group',
+      'uid' => 1,
+    ]);
+    $node->setPublished()->save();
+
+    // Login as test user.
+    $this->drupalLogin($user);
+
+    // Get expected values.
+    $settings = $config->getSettings();
+    $tokens = [
+      '%user' => $user->getDisplayName(),
+      '%group' => $node->label(),
+    ];
+    $sub_message = HAGroupSubscribeFormatter::replaceTokens($settings['sub_message'], $tokens);
+    $sub_message_approval = HAGroupSubscribeFormatter::replaceTokens($settings['sub_message_approval'], $tokens);
+
+    // Visit our test group page.
+    $this->drupalGet($node->toUrl());
+
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->linkByHrefExists('/group/node/' . $node->id() . '/subscribe');
+    // Either $sub_message or $sub_message_approval label should be present.
+    try {
+      $this->assertSession()->linkExists($sub_message);
+    }
+    catch (ExpectationException $e) {
+      // Try $sub_message_approval.
+      $this->assertSession()->linkExists($sub_message_approval);
+    }
+  }
+
+}


### PR DESCRIPTION
## Overview
This is a custom module called 'Home Assignment'. This module fixes the issue #1 by providing a way to configure the group subscription message from the UI.

## Before
There was no way to update the subscription message for a group and it will only display the default message 'Request group membership' (if approval required) or 'Subscribe to group' (approval not required).
![screenshot-drupal8-tests ddev site_8880-2020 07 15-02_19_09](https://user-images.githubusercontent.com/1091810/87475503-8b928d00-c642-11ea-889c-cf33e79b809f.png)

## After
A new field formatter plugin is added that allows us to update the subscription message for a group. It also supports using user name and group name in the message using '%user' and '%group' tokens.
Custom message can be configured as follows.
![screenshot-drupal8-tests ddev site_8880-2020 07 15-02_15_30](https://user-images.githubusercontent.com/1091810/87475528-951bf500-c642-11ea-9bba-d80464ef153d.png)
![gif](https://user-images.githubusercontent.com/1091810/87475532-99e0a900-c642-11ea-948a-41ff048200a7.gif)

## Technical Details
This issue is solved by creating a custom field formatter plugin for 'og_group' field display. This field formatter, 'HAGroupSubscribeFormatter' extends the default 'GroupSubscribeFormatter' and adds 2 fields to set custom subscription messages (one for with approval and one without). Support for using user name and group names in these messages is added by using '%user' and '%group' tokens in the message which are handled using basic string manipulation.
In addition to the formatter plugin, the module also creates a new content type called 'Group' (ha_group) which is configured as an OG group and this will have the new field formatter set.
A functional test is added for this functionality that creates a user, creates a group node and tests if the custom subscription message is displayed. 